### PR TITLE
Add request parameters to default log format

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url 
  * Default format.
  */
 
-morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
+morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params')
 deprecate.property(morgan, 'default', 'default format: use combined format')
 
 /**
@@ -341,6 +341,14 @@ morgan.token('req', function getRequestToken (req, res, field) {
   return Array.isArray(header)
     ? header.join(', ')
     : header
+})
+
+/**
+ * request parameters
+ */
+
+morgan.token('params', function getParamsToken (req) {
+  return JSON.stringify(req.params)
 })
 
 /**


### PR DESCRIPTION
This pull request modifies the default log format in morgan to include request parameters. The changes include:

1. Adding a new token 'params' to extract request parameters
2. Updating the default format to include the new 'params' token

These changes will provide more detailed logging information, including the request parameters in each log entry.