### PR TITLE
Add request parameters to Morgan logging format

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,16 @@ morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url 
  * Default format.
  */
 
-morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
+morgan.token('params', function getParamsToken (req) {
+  const params = {
+    query: req.query || {},
+    body: req.body || {},
+    params: req.params || {}
+  }
+  return JSON.stringify(params)
+})
+
+morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" params::params')
 deprecate.property(morgan, 'default', 'default format: use combined format')
 
 /**


### PR DESCRIPTION
## Changes

- Added a new Morgan token `params` to capture request parameters
- Modified the default Morgan format to include the new `params` token

## Details

- The new `params` token captures query parameters, body parameters, and route parameters
- Parameters are added at the end of each log entry in JSON format
- This change enhances logging capabilities by providing more detailed information about incoming requests

## Testing

Please verify that the new logging format includes request parameters as expected across different types of requests (GET, POST, etc.) with various parameter combinations.