### PR TITLE
Add request parameters to Morgan logging format

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url 
  * Default format.
  */
 
-morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
+morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" params=:params')
 deprecate.property(morgan, 'default', 'default format: use combined format')
 
 /**
@@ -328,6 +328,13 @@ morgan.token('http-version', function getHttpVersionToken (req) {
 
 morgan.token('user-agent', function getUserAgentToken (req) {
   return req.headers['user-agent']
+})
+
+/**
+ * request parameters
+ */
+morgan.token('params', function getParamsToken (req) {
+  return JSON.stringify(req.params || {})
 })
 
 /**


### PR DESCRIPTION
## Changes

This PR enhances the Morgan middleware logging by including request parameters in the log output.

### Added
- New Morgan token `params` that serializes request parameters
- Extended default log format to include parameters at the end of each log entry

### Example Output
```
192.168.1.1 - user [2023-07-20] "GET /api/users/123 HTTP/1.1" 200 1234 "http://example.com" "Mozilla/5.0" params={"id":"123"}
```

This change will improve debugging and monitoring capabilities by making request parameters visible in the logs.