### PR TITLE
Add request params to default log format

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url 
  * Default format.
  */
 
-morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
+morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params')
 deprecate.property(morgan, 'default', 'default format: use combined format')
 
 /**
@@ -358,6 +358,14 @@ morgan.token('res', function getResponseHeader (req, res, field) {
   return Array.isArray(header)
     ? header.join(', ')
     : header
+})
+
+/**
+ * request params
+ */
+
+morgan.token('params', function getParamsToken (req) {
+  return JSON.stringify(req.params)
 })
 
 /**


### PR DESCRIPTION
This PR adds a new `:params` token to include request parameters in the log output. Changes include:

- Added a new `params` token that stringifies `req.params`
- Modified the default format to include the new `:params` token at the end

These changes will improve debugging and monitoring of requests by including the request parameters in the log output. The new token is defined as:

```javascript
morgan.token('params', function getParamsToken (req) {
  return JSON.stringify(req.params)
})
```

And the updated default format now looks like:

```javascript
morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params')
```

This enhancement will provide more detailed logging information for each request, making it easier to track and analyze API usage.