### PR TITLE
Add request params to default log format

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,10 +158,18 @@ morgan.format('combined', ':remote-addr - :remote-user [:date[clf]] ":method :ur
 morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]')
 
 /**
+ * request params
+ */
+
+morgan.token('params', function getParamsToken (req) {
+  return JSON.stringify(req.params)
+})
+
+/**
  * Default format.
  */
 
-morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
+morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params')
 deprecate.property(morgan, 'default', 'default format: use combined format')
 
 /**


### PR DESCRIPTION
This PR adds request parameters to the default log format in Morgan middleware for improved debugging and monitoring. Changes include:

- Added a new token 'params' to stringify request parameters
- Updated the default format to include the new 'params' token

These changes are made to the `index.js` file in the root directory, which is the main file for the Morgan middleware. The modifications will provide more detailed logging information, including request parameters, in the default log format.

### Changes:
1. Added new token definition:
```javascript
morgan.token('params', function getParamsToken (req) {
  return JSON.stringify(req.params)
})
```

2. Updated default format:
```javascript
morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params')
```

These changes comply with the existing code style in the repository, as indicated by the presence of `.eslintrc.yml` files.