### PR TITLE
Add request parameters to default log format

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,10 @@
-1.10.0 / 2020-03-20
+1.11.0 / 2023-05-24
+===================
+
+  * Add `:params` token for logging request parameters
+  * Include `:params` token in default log format
+
+1.10.0 / 2019-06-10
 ===================
 
   * Add `:total-time` token

--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ for information codes.
 :method :url :status :response-time ms - :res[content-length]
 ```
 
+##### default
+
+Standard output including request parameters.
+
+```
+:remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params
+```
+
 ##### short
 
 Shorter than default, also including response time.
@@ -237,6 +245,10 @@ The URL of the request. This will use `req.originalUrl` if exists, otherwise `re
 ##### :user-agent
 
 The contents of the User-Agent header of the request.
+
+##### :params
+
+The request parameters as a JSON string.
 
 ### morgan.compile(format)
 

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ morgan.format('common', ':remote-addr - :remote-user [:date[clf]] ":method :url 
  * Default format.
  */
 
-morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"')
+morgan.format('default', ':remote-addr - :remote-user [:date] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent" :params')
 deprecate.property(morgan, 'default', 'default format: use combined format')
 
 /**
@@ -328,6 +328,14 @@ morgan.token('http-version', function getHttpVersionToken (req) {
 
 morgan.token('user-agent', function getUserAgentToken (req) {
   return req.headers['user-agent']
+})
+
+/**
+ * request parameters
+ */
+
+morgan.token('params', function getParamsToken (req) {
+  return JSON.stringify(req.params)
 })
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "morgan",
   "description": "HTTP request logger middleware for node.js",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"


### PR DESCRIPTION
This PR adds a new `:params` token for logging request parameters and includes it in the default log format. Changes include:

- Added new `params` token to output request parameters as JSON string
- Updated default log format to include the new `:params` token
- Updated README.md to document the new token and updated default format
- Updated HISTORY.md with new version entry (1.11.0)
- Incremented version number in package.json to 1.11.0

These changes enhance the logging capabilities of morgan by including request parameters in the default log output, providing more detailed information for debugging and monitoring.